### PR TITLE
FIX: create `generated_*` directory if not present

### DIFF
--- a/src/parser/lrparser.y
+++ b/src/parser/lrparser.y
@@ -1,9 +1,10 @@
-%define parse.trace
 %{
 	#include <stdio.h>
 	#include <string.h>
 	#include <stdlib.h>
 	#include <stdbool.h>
+    #include <sys/stat.h>
+    #include <sys/types.h>
     #include "includeHeader.hpp"
 	#include "../analyser/attachProp/attachPropAnalyser.h"
 	#include "../analyser/dataRace/dataRaceAnalyser.h"
@@ -68,6 +69,7 @@
 %token <fval> FLOAT_NUM
 %token <bval> BOOL_VAL
 %token <cval> CHAR_VAL
+%token return_func
 
 %type <node> function_def function_data  return_func function_body param
 %type <pList> paramList
@@ -496,6 +498,20 @@ id : ID   {
 
 %%
 
+void create_directory(const char *backendTarget) {
+    char directory_name[256];
+    snprintf(directory_name, sizeof(directory_name), "../graphcode/generated_%s", backendTarget);
+    // Check if directory exists
+    struct stat st = {0};
+    if (stat(directory_name, &st) == -1) {
+        // Check if the mkdir fails
+        if (mkdir(directory_name, 0700) == -1) {
+            perror("mkdir");
+        }
+    } else {
+        printf("Directory already exists %s\n", directory_name);
+    }
+}
 
 void yyerror(const char *s) {
     fprintf(stderr, "%s\n", s);


### PR DESCRIPTION
### PR Description
**Problem:**
Cloning the current project and running the Makefile breaks the build because the linker failed to identify the tokens. Additionally, running the StarPlat binary does not generate the generated_backend folder in {PWD}/graphcode/.

**Solution:**
The following changes address these issues and have been tested locally on both Mac and PopOS variants:

**Changes:**

- Removed the definition for `parse.trace` to ensure proper linking and added `return_func` as a token.
- Added a utility to create a directory if it is not present.


**Testing:**

##### Valid build flag
```  
./StarPlat -s -f ../graphcode/staticDSLCodes/triangle_counting_dsl -b omp
tree ../graphcode/generated_omp             
../graphcode/generated_omp
├── triangle_counting_dsl.cc
├── triangle_counting_dsl.h
└── triangle_counting_dsl_cl.cc
```

##### Invalid build flag
```
./StarPlat -s -f ../graphcode/staticDSLCodes/triangle_counting_dsl -b unknown_target
fileName ../graphcode/staticDSLCodes/triangle_counting_dsl
Backend Target unknown_target
Specified backend target is not implemented in the current version!

ls ../graphcode 
atomicUtil.h        graph.hpp           graph_ompv2.hpp     sample_graphs       update.hpp
generated_omp       graphUndirected.hpp main.cpp            staticDSLCodes
```
